### PR TITLE
feat: Friends of Figma Nagoyaの登壇実績を追加

### DIFF
--- a/src/content/talks/2025.json
+++ b/src/content/talks/2025.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "Friends of Figma Nagoya グリッドが搭載されたオートレイアウトを学ぼう！",
+    "url": "https://friends.figma.com/events/details/figma-nagoya-presents-guritsudogada-zai-saretaotoreiautowoxue-bou/",
+    "date": "2025-07-25"
+  },
+  {
     "id": "Figma Config 2025はどうだった？現地参加者たちを招いたRecapイベント",
     "url": "https://cybozu.connpass.com/event/358821/",
     "date": "2025-06-23"


### PR DESCRIPTION
Friends of Figma Nagoyaの登壇実績を追加しました。

## 変更内容
- `src/content/talks/2025.json`の2025年7月25日に「Friends of Figma Nagoya グリッドが搭載されたオートレイアウトを学ぼう！」イベントを追加
- イベントURLを含む完全な情報を記載

Fixes #320

Generated with [Claude Code](https://claude.ai/code)